### PR TITLE
Fix Ethereum address verifier test

### DIFF
--- a/src/ownership-verifiers/ethereum.test.ts
+++ b/src/ownership-verifiers/ethereum.test.ts
@@ -55,7 +55,7 @@ test("Try to commit to an address with an invalid signature, should throw", asyn
       ethSignature: malformedsignature,
     })
   ).rejects.toThrow(
-    'signature missing v and recoveryParam (argument="signature", value="0x345", code=INVALID_ARGUMENT, version=bytes/5.6.1)'
+    /(signature missing v and recoveryParam)/
   );
 });
 


### PR DESCRIPTION
The only failing test, caused by mismatch on version. Fixed by using RegExp.